### PR TITLE
Use forked Adafruit_TinyUSB_Arduino

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "libraries/Adafruit_nRFCrypto"]
 	path = libraries/Adafruit_nRFCrypto
 	url = https://github.com/adafruit/Adafruit_nRFCrypto.git
+[submodule "libraries/Adafruit_TinyUSB_Arduino"]
+	path = libraries/Adafruit_TinyUSB_Arduino
+	url = git@github.com:ryanrsrs/Adafruit_TinyUSB_Arduino.git
+	branch = luatt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "libraries/Adafruit_nRFCrypto"]
 	path = libraries/Adafruit_nRFCrypto
 	url = https://github.com/adafruit/Adafruit_nRFCrypto.git
-[submodule "libraries/Adafruit_TinyUSB_Arduino"]
-	path = libraries/Adafruit_TinyUSB_Arduino
-	url = https://github.com/adafruit/Adafruit_TinyUSB_Arduino.git

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "framework-arduinoadafruitnrf52",
+  "version": "2.0.0",
+  "description": "Arduino Wiring-based Framework for Nordic Semiconductor nRF52 BLE SoC",
+  "keywords": [
+    "framework",
+    "arduino",
+    "nordic semiconductor",
+    "nrf52"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryanrsrs/Adafruit_nRF52_Arduino"
+  }
+}


### PR DESCRIPTION
Add token-based muxing out output streams. This lets us redirect naked printfs to the right Lua REPL. The scheduler updates the token with thread switches.